### PR TITLE
header key 'X-Forwarded-For' in some apps can be in camel-case

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function forwarded (req) {
   }
 
   // simple header parsing
-  var proxyAddrs = parse(req.headers['x-forwarded-for'] || '')
+  var proxyAddrs = parse(req.headers['x-forwarded-for'] || req.headers['X-Forwarded-For'] || '')
   var socketAddr = req.connection.remoteAddress
   var addrs = [socketAddr].concat(proxyAddrs)
 

--- a/test/test.js
+++ b/test/test.js
@@ -20,6 +20,13 @@ describe('forwarded(req)', function () {
     assert.deepEqual(forwarded(req), ['127.0.0.1', '10.0.0.1', '10.0.0.2'])
   })
 
+  it('should include entries from X-Forwarded-For when key is in camel-case', function () {
+    var req = createReq('127.0.0.1', {
+      'X-Forwarded-For': '10.0.0.2, 10.0.0.1'
+    })
+    assert.deepEqual(forwarded(req), ['127.0.0.1', '10.0.0.1', '10.0.0.2'])
+  })
+
   it('should skip blank entries', function () {
     var req = createReq('127.0.0.1', {
       'x-forwarded-for': '10.0.0.2,, 10.0.0.1'


### PR DESCRIPTION
(for example when Amazon Lambda is accessed via API Gateway),
so we need to check it too