### PR TITLE
Use req.socket instead of req.connection #8

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function forwarded (req) {
 
   // simple header parsing
   var proxyAddrs = parse(req.headers['x-forwarded-for'] || '')
-  var socketAddr = req.connection.remoteAddress
+  var socketAddr = req.socket.remoteAddress
   var addrs = [socketAddr].concat(proxyAddrs)
 
   // return all addresses

--- a/test/test.js
+++ b/test/test.js
@@ -37,7 +37,7 @@ describe('forwarded(req)', function () {
 
 function createReq (socketAddr, headers) {
   return {
-    connection: {
+    socket: {
       remoteAddress: socketAddr
     },
     headers: headers || {}


### PR DESCRIPTION

Fixes #8

I used [fastify](https://github.com/fastify/fastify) and [jshttp/forwarded](https://github.com/jshttp/forwarded) generate a warning due to that deprecation usage.

Related [fastify](https://github.com/fastify/fastify) issues :

- https://github.com/fastify/fastify/pull/2594
- https://github.com/fastify/light-my-request/pull/99
