### PR TITLE
Update MD_HEADER_REGEXP to require at least 4 equals signs

### DIFF
--- a/scripts/version-history.js
+++ b/scripts/version-history.js
@@ -4,7 +4,7 @@ var fs = require('fs')
 var path = require('path')
 
 var HISTORY_FILE_PATH = path.join(__dirname, '..', 'HISTORY.md')
-var MD_HEADER_REGEXP = /^====*$/
+var MD_HEADER_REGEXP = /^={4,}$/
 var VERSION = process.env.npm_package_version
 var VERSION_PLACEHOLDER_REGEXP = /^(?:unreleased|(\d+\.)+x)$/
 


### PR DESCRIPTION
updates the regular expression for validating the header in HISTORY.md. The new pattern enforces at least 4 consecutive equals signs (=) instead of any number of equals signs.

Changes:
Old RegExp: /^====*$/ (allowed any number of equals signs).
New RegExp: /^={4,}$/ (requires at least 4 equals signs).
Rationale:
This ensures a more consistent and readable header format in HISTORY.md