### PR TITLE
fix: handle undefined remoteAddress when socket is disconnected

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function forwarded (req) {
   // simple header parsing
   var proxyAddrs = parse(req.headers['x-forwarded-for'] || '')
   var socketAddr = getSocketAddr(req)
-  var addrs = [socketAddr].concat(proxyAddrs)
+  var addrs = (socketAddr ? [socketAddr] : []).concat(proxyAddrs)
 
   // return all addresses
   return addrs
@@ -44,9 +44,8 @@ function forwarded (req) {
  */
 
 function getSocketAddr (req) {
-  return req.socket
-    ? req.socket.remoteAddress
-    : req.connection.remoteAddress
+  var socket = req.socket || req.connection
+  return socket ? socket.remoteAddress : undefined
 }
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -58,6 +58,18 @@ describe('forwarded(req)', function () {
       var req = createReq('connection', '10.0.0.1')
       assert.strictEqual(forwarded(req)[0], '10.0.0.1')
     })
+
+    it('should omit socket address when socket is disconnected', function () {
+      var req = { headers: {}, socket: { remoteAddress: undefined } }
+      var addrs = forwarded(req)
+      assert.strictEqual(addrs.indexOf(undefined), -1)
+    })
+
+    it('should omit socket address when both socket and connection are absent', function () {
+      var req = { headers: {} }
+      var addrs = forwarded(req)
+      assert.strictEqual(addrs.indexOf(undefined), -1)
+    })
   })
 })
 


### PR DESCRIPTION
Fixes #12

## Problem

`getSocketAddr` returned `undefined` in two cases:

1. `req.socket` exists but `remoteAddress` is `undefined` (socket was disconnected)
2. `req.socket` is falsy and `req.connection` is also absent — accessing `.remoteAddress` on `undefined` throws

The `undefined` then leaked into the `addrs` array returned by `forwarded()`.

## Fix

- `getSocketAddr`: safely read `remoteAddress` from whichever of `req.socket` / `req.connection` is present; return `undefined` if neither has an address
- `forwarded()`: skip the socket address when it is `undefined` rather than including it in the result

## Testing

Added two new tests for the disconnected-socket cases. All 11 tests pass.